### PR TITLE
Add Sanity-managed territory coverage (states and counties)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # W-Cubed Landing Page
 
-A modern, responsive landing page for W-Cubed - Mountain West's premier water equipment representative, built with Next.js 14, TypeScript, and Tailwind CSS.
+A modern, responsive landing page for W-Cubed - Mountain West's premier water
+equipment representative, built with Next.js 14, TypeScript, and Tailwind CSS.
 
 ## Features
 
@@ -23,22 +24,33 @@ A modern, responsive landing page for W-Cubed - Mountain West's premier water eq
 ### Installation
 
 1. Clone the repository:
+
 ```bash
 git clone https://github.com/Tbsheff/w-cubed-landing-page.git
 cd w-cubed-landing-page
 ```
 
 2. Install dependencies:
+
 ```bash
 pnpm install
 ```
 
-3. Set up environment variables (if needed):
+3. Set up environment variables:
+
 ```bash
 cp .env.example .env.local
 ```
 
+Then edit `.env.local` and fill in the required values:
+
+- `NEXT_PUBLIC_SANITY_PROJECT_ID` - Your Sanity project ID
+- `NEXT_PUBLIC_SANITY_DATASET` - Your Sanity dataset (e.g., `production`)
+- `NEXT_PUBLIC_SANITY_API_VERSION` - Sanity API version (default: `2025-09-15`)
+- `REVALIDATE_SECRET` - Secret for on-demand revalidation webhooks
+
 4. Run the development server:
+
 ```bash
 pnpm dev
 ```
@@ -47,14 +59,14 @@ Open [http://localhost:3000](http://localhost:3000) to view the application.
 
 ## Available Scripts
 
-| Script | Description |
-|--------|------------|
-| `pnpm dev` | Start the development server |
-| `pnpm build` | Build the production application |
-| `pnpm start` | Start the production server |
-| `pnpm lint` | Run ESLint for code quality |
-| `pnpm typecheck` | Run TypeScript type checking |
-| `pnpm clean` | Remove build cache and node_modules |
+| Script           | Description                         |
+| ---------------- | ----------------------------------- |
+| `pnpm dev`       | Start the development server        |
+| `pnpm build`     | Build the production application    |
+| `pnpm start`     | Start the production server         |
+| `pnpm lint`      | Run ESLint for code quality         |
+| `pnpm typecheck` | Run TypeScript type checking        |
+| `pnpm clean`     | Remove build cache and node_modules |
 
 ## Project Structure
 
@@ -74,6 +86,35 @@ w-cubed/
 └── sanity/              # Sanity CMS configuration
 ```
 
+## Deployment
+
+### Required Environment Variables
+
+For production builds, you **must** set the following environment variables in
+your deployment platform (e.g., Vercel, Netlify):
+
+**Required:**
+
+- `NEXT_PUBLIC_SANITY_PROJECT_ID` - Your Sanity project ID
+- `NEXT_PUBLIC_SANITY_DATASET` - Your Sanity dataset (e.g., `production`)
+
+**Optional:**
+
+- `NEXT_PUBLIC_SANITY_API_VERSION` - Sanity API version (defaults to
+  `2025-09-15` if not set)
+- `REVALIDATE_SECRET` - Secret for on-demand revalidation webhooks (required for
+  webhook-based revalidation)
+
+### Vercel Deployment
+
+1. Connect your repository to Vercel
+2. Add the required environment variables in Project Settings → Environment
+   Variables
+3. Deploy
+
+The build will fail if `NEXT_PUBLIC_SANITY_PROJECT_ID` or
+`NEXT_PUBLIC_SANITY_DATASET` are not set.
+
 ## CI/CD
 
 This project uses GitHub Actions for continuous integration:
@@ -85,16 +126,19 @@ This project uses GitHub Actions for continuous integration:
 ### CI Pipeline
 
 The CI pipeline runs on:
+
 - Pull requests to `main`
 - Pushes to `main`
 
 It performs:
+
 1. TypeScript type checking (`pnpm typecheck`)
 2. ESLint linting (`pnpm lint`)
 
 ## Technology Stack
 
 ### Frontend
+
 - **Framework**: Next.js 14 (App Router)
 - **Language**: TypeScript
 - **Styling**: Tailwind CSS
@@ -103,11 +147,13 @@ It performs:
 - **Forms**: React Hook Form with Zod validation
 
 ### Content Management
+
 - **CMS**: Sanity v4
 - **Image Handling**: Sanity Image URL builder
 - **Content Queries**: GROQ
 
 ### Development Tools
+
 - **Package Manager**: pnpm
 - **Linting**: ESLint with Next.js configuration
 - **Type Checking**: TypeScript strict mode

--- a/lib/sanity.queries.ts
+++ b/lib/sanity.queries.ts
@@ -121,12 +121,11 @@ export const representativesQuery = groq`*[_type == "representative"]|order(coal
   role,
   phone,
   email,
-  states,
   regions,
-  servedStates,
-  servedCounties[]{
-    state,
-    county
+  "servedStates": servedStates[]->code,
+  "servedCounties": servedCounties[]->{
+    "state": state->code,
+    "county": name
   },
   photo
 }`
@@ -138,6 +137,25 @@ export const territoryInfoQuery = groq`*[_type == "territoryInfo"][0]{
   secondaryCta,
   coverageBlurb,
   businessHours
+}`
+
+export const statesListQuery = groq`*[_type == "state"]|order(coalesce(order, 9999) asc, name asc){
+  _id,
+  name,
+  code
+}`
+
+export const countiesListQuery = groq`*[_type == "county"]|order(name asc){
+  _id,
+  name,
+  "stateCode": state->code,
+  "stateName": state->name
+}`
+
+export const countiesByStateQuery = groq`*[_type == "county" && state->code == $stateCode]|order(name asc){
+  _id,
+  name,
+  "stateCode": state->code
 }`
 
 export const categoriesListQuery = groq`*[_type == "category"]{ title }`

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/sanity/schemaTypes/county.ts
+++ b/sanity/schemaTypes/county.ts
@@ -1,0 +1,51 @@
+import { defineField, defineType } from 'sanity'
+
+export default defineType({
+  name: 'county',
+  title: 'County',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      description: 'County name (e.g., "Salt Lake")',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'state',
+      title: 'State',
+      type: 'reference',
+      to: [{ type: 'state' }],
+      validation: (rule) => rule.required(),
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Name',
+      name: 'nameAsc',
+      by: [{ field: 'name', direction: 'asc' }],
+    },
+    {
+      title: 'State, then Name',
+      name: 'stateNameAsc',
+      by: [
+        { field: 'state.name', direction: 'asc' },
+        { field: 'name', direction: 'asc' },
+      ],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      stateName: 'state.name',
+      stateCode: 'state.code',
+    },
+    prepare({ title, stateName, stateCode }) {
+      return {
+        title: title || 'Untitled County',
+        subtitle: stateCode ? `${stateName} (${stateCode})` : stateName,
+      }
+    },
+  },
+})

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -7,7 +7,20 @@ import manufacturer from './manufacturer'
 import siteSettings from './siteSettings'
 import representative from './representative'
 import territoryInfo from './territoryInfo'
+import state from './state'
+import county from './county'
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [post, author, category, project, manufacturer, siteSettings, representative, territoryInfo],
+  types: [
+    post,
+    author,
+    category,
+    project,
+    manufacturer,
+    siteSettings,
+    representative,
+    territoryInfo,
+    state,
+    county,
+  ],
 }

--- a/sanity/schemaTypes/representative.ts
+++ b/sanity/schemaTypes/representative.ts
@@ -40,18 +40,16 @@ export default defineType({
       options: { hotspot: true },
     }),
     defineField({
-      name: 'states',
-      title: 'States (Display)',
-      type: 'array',
-      of: [{ type: 'string' }],
-      description: 'Display names for states (e.g., "Utah", "Nevada")',
-    }),
-    defineField({
       name: 'servedStates',
-      title: 'Served States (Codes)',
+      title: 'Served States',
       type: 'array',
-      of: [{ type: 'string' }],
-      description: 'State codes for territory coverage (e.g., "UT", "NV")',
+      of: [
+        {
+          type: 'reference',
+          to: [{ type: 'state' }],
+        },
+      ],
+      description: 'Full states this representative covers',
     }),
     defineField({
       name: 'servedCounties',
@@ -59,14 +57,11 @@ export default defineType({
       type: 'array',
       of: [
         {
-          type: 'object',
-          fields: [
-            defineField({ name: 'state', title: 'State Code', type: 'string' }),
-            defineField({ name: 'county', title: 'County Name', type: 'string' }),
-          ],
+          type: 'reference',
+          to: [{ type: 'county' }],
         },
       ],
-      description: 'Specific counties served (optional, for partial state coverage)',
+      description: 'Specific counties for partial state coverage (optional)',
     }),
     defineField({
       name: 'regions',
@@ -79,5 +74,11 @@ export default defineType({
       type: 'number',
     }),
   ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'role',
+      media: 'photo',
+    },
+  },
 })
-

--- a/sanity/schemaTypes/state.ts
+++ b/sanity/schemaTypes/state.ts
@@ -1,0 +1,63 @@
+import { defineField, defineType } from 'sanity'
+
+export default defineType({
+  name: 'state',
+  title: 'State',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'name',
+      title: 'Name',
+      type: 'string',
+      description: 'Full state name (e.g., "Utah")',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'code',
+      title: 'Code',
+      type: 'string',
+      description: 'Two-letter state code (e.g., "UT")',
+      validation: (rule) =>
+        rule
+          .required()
+          .length(2)
+          .uppercase()
+          .custom((value) => {
+            if (value && !/^[A-Z]{2}$/.test(value)) {
+              return 'Must be exactly 2 uppercase letters'
+            }
+            return true
+          }),
+    }),
+    defineField({
+      name: 'order',
+      title: 'Display Order',
+      type: 'number',
+      description: 'Order in lists (lower numbers first)',
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Name',
+      name: 'nameAsc',
+      by: [{ field: 'name', direction: 'asc' }],
+    },
+    {
+      title: 'Code',
+      name: 'codeAsc',
+      by: [{ field: 'code', direction: 'asc' }],
+    },
+  ],
+  preview: {
+    select: {
+      title: 'name',
+      subtitle: 'code',
+    },
+    prepare({ title, subtitle }) {
+      return {
+        title: title || 'Untitled State',
+        subtitle: subtitle ? `(${subtitle})` : undefined,
+      }
+    },
+  },
+})

--- a/sanity/seed/seed.ndjson
+++ b/sanity/seed/seed.ndjson
@@ -1,9 +1,126 @@
 {"_type":"siteSettings","_id":"siteSettings-singleton","heroBadge":"Serving the Mountain West Since 1986","heroTitle":"Water, Waste‑water, Equipment experts","heroDescription":"Your trusted partner for water treatment, pumping systems, and process equipment. Delivering reliable solutions across the Mountain West for nearly four decades.","primaryCta":{"label":"Get Project Quote","href":"/contact"},"secondaryCta":{"label":"Browse Equipment","href":"/manufacturers"},"stats":[{"value":"38+","label":"Years in Business","detail":"Serving the Mountain West since 1986"},{"value":"10+","label":"Trusted Manufacturers","detail":"Premium equipment partnerships"},{"value":"4-State","label":"Coverage Area","detail":"Utah, Nevada, Idaho, and Wyoming"}],"manufacturerStrip":[{"_type":"reference","_ref":"manufacturer-ksb"},{"_type":"reference","_ref":"manufacturer-kaeser"},{"_type":"reference","_ref":"manufacturer-pratt"},{"_type":"reference","_ref":"manufacturer-hydro-gate"},{"_type":"reference","_ref":"manufacturer-fournier"},{"_type":"reference","_ref":"manufacturer-edi"},{"_type":"reference","_ref":"manufacturer-veolia-suez"},{"_type":"reference","_ref":"manufacturer-trillium-flow"},{"_type":"reference","_ref":"manufacturer-kusters-zima"},{"_type":"reference","_ref":"manufacturer-pentair-fairbanks"}],"highlights":[{"title":"Municipal Water Treatment Facilities","description":"Successfully designed and installed pumping systems for municipal water and wastewater treatment plants across our four-state territory.","category":"Municipal","states":["UT","NV","ID","WY"],"image":null},{"title":"Industrial Plant Solutions","description":"Custom water-process equipment solutions for manufacturing facilities, mines, and processing plants throughout the Mountain West.","category":"Industrial","states":["UT","ID"],"image":null},{"title":"Commercial & Infrastructure","description":"Reliable pumping and treatment systems for commercial developments, resorts, and infrastructure projects.","category":"Commercial","states":["NV","WY"],"image":null}]}
 {"_type":"territoryInfo","_id":"territoryInfo-singleton","heroTitle":"Four-State Coverage Area","heroSubtitle":"Our experienced representatives provide personalized service across Utah, Nevada, Idaho, and Wyoming. Find your local representative and discover the counties we serve.","primaryCta":{"label":"Find Your Representative","href":"/contact"},"secondaryCta":{"label":"View All Products","href":"/manufacturers"},"coverageBlurb":"Serving Utah, Nevada, Idaho, and Wyoming with dedicated regional reps.","businessHours":[{"label":"Monday - Friday","value":"8:00 AM - 5:00 PM MT"},{"label":"Saturday","value":"By Appointment"},{"label":"Sunday","value":"Closed"}]}
-{"_type":"representative","_id":"rep-brad-gwinnup","name":"Brad Gwinnup","slug":{"_type":"slug","current":"brad-gwinnup"},"role":"Utah, Nevada","phone":"801-232-8241","email":"Bradg@wcubedinc.com","states":["Utah","Nevada"],"servedStates":["UT","NV"],"servedCounties":[],"regions":"President","order":1}
-{"_type":"representative","_id":"rep-austin-gwinnup","name":"Austin Gwinnup","slug":{"_type":"slug","current":"austin-gwinnup"},"role":"Idaho, Wyoming","phone":"801-803-8558","email":"Austing@wcubedinc.com","states":["Idaho","Wyoming"],"servedStates":["ID","WY"],"servedCounties":[],"regions":"Sales Representative","order":2}
-{"_type":"representative","_id":"rep-cason-gwinnup","name":"Cason Gwinnup","slug":{"_type":"slug","current":"cason-gwinnup"},"role":"Aftermarket Sales","phone":"801-664-2438","email":"Casong@wcubedinc.com","states":["All Territories"],"servedStates":["UT","NV","ID","WY"],"servedCounties":[],"regions":"Application Engineer/Project Manager","order":3}
-{"_type":"representative","_id":"rep-robert-haws","name":"Robert Haws","slug":{"_type":"slug","current":"robert-haws"},"role":"Parts","phone":"385-270-6128","email":"Roberth@wcubedinc.com","states":["All Territories"],"servedStates":["UT","NV","ID","WY"],"servedCounties":[],"regions":"Application Engineer/Project Manager","order":4}
+{"_type":"state","_id":"state-ut","name":"Utah","code":"UT","order":1}
+{"_type":"state","_id":"state-nv","name":"Nevada","code":"NV","order":2}
+{"_type":"state","_id":"state-id","name":"Idaho","code":"ID","order":3}
+{"_type":"state","_id":"state-wy","name":"Wyoming","code":"WY","order":4}
+{"_type":"county","_id":"county-ut-beaver","name":"Beaver","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-box-elder","name":"Box Elder","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-cache","name":"Cache","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-carbon","name":"Carbon","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-daggett","name":"Daggett","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-davis","name":"Davis","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-duchesne","name":"Duchesne","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-emery","name":"Emery","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-garfield","name":"Garfield","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-grand","name":"Grand","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-iron","name":"Iron","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-juab","name":"Juab","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-kane","name":"Kane","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-millard","name":"Millard","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-morgan","name":"Morgan","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-piute","name":"Piute","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-rich","name":"Rich","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-salt-lake","name":"Salt Lake","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-san-juan","name":"San Juan","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-sanpete","name":"Sanpete","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-sevier","name":"Sevier","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-summit","name":"Summit","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-tooele","name":"Tooele","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-uintah","name":"Uintah","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-utah","name":"Utah","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-wasatch","name":"Wasatch","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-washington","name":"Washington","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-wayne","name":"Wayne","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-ut-weber","name":"Weber","state":{"_type":"reference","_ref":"state-ut"}}
+{"_type":"county","_id":"county-nv-carson-city","name":"Carson City","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-churchill","name":"Churchill","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-clark","name":"Clark","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-douglas","name":"Douglas","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-elko","name":"Elko","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-esmeralda","name":"Esmeralda","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-eureka","name":"Eureka","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-humboldt","name":"Humboldt","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-lander","name":"Lander","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-lincoln","name":"Lincoln","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-lyon","name":"Lyon","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-mineral","name":"Mineral","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-nye","name":"Nye","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-pershing","name":"Pershing","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-storey","name":"Storey","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-washoe","name":"Washoe","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-nv-white-pine","name":"White Pine","state":{"_type":"reference","_ref":"state-nv"}}
+{"_type":"county","_id":"county-id-ada","name":"Ada","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-adams","name":"Adams","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-bannock","name":"Bannock","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-bear-lake","name":"Bear Lake","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-benewah","name":"Benewah","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-bingham","name":"Bingham","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-blaine","name":"Blaine","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-boise","name":"Boise","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-bonner","name":"Bonner","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-bonneville","name":"Bonneville","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-boundary","name":"Boundary","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-butte","name":"Butte","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-camas","name":"Camas","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-canyon","name":"Canyon","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-caribou","name":"Caribou","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-cassia","name":"Cassia","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-clark","name":"Clark","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-clearwater","name":"Clearwater","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-custer","name":"Custer","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-elmore","name":"Elmore","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-franklin","name":"Franklin","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-fremont","name":"Fremont","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-gem","name":"Gem","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-gooding","name":"Gooding","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-idaho","name":"Idaho","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-jefferson","name":"Jefferson","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-jerome","name":"Jerome","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-kootenai","name":"Kootenai","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-latah","name":"Latah","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-lemhi","name":"Lemhi","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-lewis","name":"Lewis","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-lincoln","name":"Lincoln","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-madison","name":"Madison","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-minidoka","name":"Minidoka","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-nez-perce","name":"Nez Perce","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-oneida","name":"Oneida","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-owyhee","name":"Owyhee","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-payette","name":"Payette","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-power","name":"Power","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-shoshone","name":"Shoshone","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-teton","name":"Teton","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-twin-falls","name":"Twin Falls","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-valley","name":"Valley","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-id-washington","name":"Washington","state":{"_type":"reference","_ref":"state-id"}}
+{"_type":"county","_id":"county-wy-albany","name":"Albany","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-big-horn","name":"Big Horn","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-campbell","name":"Campbell","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-carbon","name":"Carbon","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-converse","name":"Converse","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-crook","name":"Crook","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-fremont","name":"Fremont","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-goshen","name":"Goshen","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-hot-springs","name":"Hot Springs","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-johnson","name":"Johnson","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-laramie","name":"Laramie","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-lincoln","name":"Lincoln","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-natrona","name":"Natrona","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-niobrara","name":"Niobrara","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-park","name":"Park","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-platte","name":"Platte","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-sheridan","name":"Sheridan","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-sublette","name":"Sublette","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-sweetwater","name":"Sweetwater","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-teton","name":"Teton","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-uinta","name":"Uinta","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-washakie","name":"Washakie","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"county","_id":"county-wy-weston","name":"Weston","state":{"_type":"reference","_ref":"state-wy"}}
+{"_type":"representative","_id":"rep-brad-gwinnup","name":"Brad Gwinnup","slug":{"_type":"slug","current":"brad-gwinnup"},"role":"Utah, Nevada","phone":"801-232-8241","email":"Bradg@wcubedinc.com","servedStates":[{"_type":"reference","_ref":"state-ut"},{"_type":"reference","_ref":"state-nv"}],"servedCounties":[],"regions":"President","order":1}
+{"_type":"representative","_id":"rep-austin-gwinnup","name":"Austin Gwinnup","slug":{"_type":"slug","current":"austin-gwinnup"},"role":"Idaho, Wyoming","phone":"801-803-8558","email":"Austing@wcubedinc.com","servedStates":[{"_type":"reference","_ref":"state-id"},{"_type":"reference","_ref":"state-wy"}],"servedCounties":[],"regions":"Sales Representative","order":2}
+{"_type":"representative","_id":"rep-cason-gwinnup","name":"Cason Gwinnup","slug":{"_type":"slug","current":"cason-gwinnup"},"role":"Aftermarket Sales","phone":"801-664-2438","email":"Casong@wcubedinc.com","servedStates":[{"_type":"reference","_ref":"state-ut"},{"_type":"reference","_ref":"state-nv"},{"_type":"reference","_ref":"state-id"},{"_type":"reference","_ref":"state-wy"}],"servedCounties":[],"regions":"Application Engineer/Project Manager","order":3}
+{"_type":"representative","_id":"rep-robert-haws","name":"Robert Haws","slug":{"_type":"slug","current":"robert-haws"},"role":"Parts","phone":"385-270-6128","email":"Roberth@wcubedinc.com","servedStates":[{"_type":"reference","_ref":"state-ut"},{"_type":"reference","_ref":"state-nv"},{"_type":"reference","_ref":"state-id"},{"_type":"reference","_ref":"state-wy"}],"servedCounties":[],"regions":"Application Engineer/Project Manager","order":4}
 {"_type":"manufacturer","_id":"manufacturer-ksb","name":"KSB","slug":{"_type":"slug","current":"ksb"},"category":"Pumps & Mixers","description":"Leading manufacturer of pumps, valves, and systems for water transport and treatment.","specialty":"Municipal & Industrial Pumping & Mixing","keyProducts":["Submersible Motor Pumps","Pump Mixing Systems","Vertical Turbine Pumps"],"website":"https://www.ksb.com/en-us/product/product-catalog","featured":false,"order":1}
 {"_type":"manufacturer","_id":"manufacturer-kaeser","name":"Kaeser Blowers","slug":{"_type":"slug","current":"kaeser"},"category":"Blowers & Aeration","description":"Premium compressed air systems and blowers for water treatment applications.","specialty":"Compressed Air & Blower Systems","keyProducts":["Rotary Lobe Blowers","Rotary Screw Blowers","Turbo Blowers"],"website":"https://us.kaeser.com/products-and-solutions/blowers/","featured":false,"order":2}
 {"_type":"manufacturer","_id":"manufacturer-pratt","name":"Pratt Valves","slug":{"_type":"slug","current":"pratt"},"category":"Valves & Flow Control","description":"Comprehensive valve solutions for water and wastewater applications.","specialty":"Water & Wastewater Valves","keyProducts":["Butterfly Valves","Gate Valves","Check Valves"],"website":"https://www.henrypratt.com/products/","featured":false,"order":3}


### PR DESCRIPTION
## Summary

- Add State and County document types to Sanity schema for managing territory coverage
- Update Representative schema to use Sanity references instead of hardcoded string arrays
- Territory data (states and counties) can now be added/edited/removed directly in Sanity Studio

## Changes

### New Schemas
- **State** (`sanity/schemaTypes/state.ts`): name, code (2-letter), order
- **County** (`sanity/schemaTypes/county.ts`): name, state reference

### Updated Schemas
- **Representative**: `servedStates` and `servedCounties` now use Sanity references

### Seed Data
- Added 4 state documents (UT, NV, ID, WY)
- Added 113 county documents across all 4 states
- Updated representative documents to use references

### Queries
- Updated `representativesQuery` to dereference state/county data
- Added `statesListQuery`, `countiesListQuery`, `countiesByStateQuery`

## Test plan

- [ ] Verify Sanity Studio shows State and County document types
- [ ] Create a new State document in Sanity Studio
- [ ] Create a new County document referencing a State
- [ ] Edit a Representative and assign states/counties via reference picker
- [ ] Verify territory map still displays correctly with the new data structure